### PR TITLE
multitasking - running more than one ender build at the time

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,9 +30,13 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     ender: {
-      options: {
+      dist: {
         output: "tmp/scripts/ender",
         dependencies: ["bean", "bonzo"]
+      },
+      dist2: {
+        output: "tmp/scripts/ender.dist2",
+        dependencies: ["bean", "bonzo","qwery"]
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ grunt.loadNpmTasks('grunt-ender');
 ### Overview
 This is a temporary utility for handling Ender builds without having to always type `--use` or `--output`. Note that there is an official solution for this problem [discussed on github](https://github.com/ender-js/Ender/issues/131) that should be available soon. In the meantime, you can use this grunt task to help make using Ender easier.
 
-Usage is simple. In your Gruntfile, add an `ender` task and under the `options` part you can specify the output location and the list of dependencies.
+Usage is simple. In your Gruntfile, add an `ender` task and under the `target` part you can specify the output location and the list of dependencies.
 
 ```js
 ender: {
-  options: {
+  target: {
     output: "public/scripts/vendor/ender",
     dependencies: ["bean", "bonzo", "qwery"]
   }
@@ -50,9 +50,13 @@ In your Gruntfile.js
 ```js
 grunt.initConfig({
   ender: {
-    options: {
+    desktop: {
       output: "public/scripts/vendor/ender",
       dependencies: ["bean", "bonzo", "qwery"]
+    },
+    mobile: {
+      output: "public/scripts/vendor/ender.mobile",
+      dependencies: ["bean", "bonzo", "qwery-mobile"]
     }
   }
 });
@@ -60,7 +64,7 @@ grunt.initConfig({
 
 #### Building the Ender Library
 
-`grunt ender` or `grunt ender:build`
+`grunt ender`
 
 #### Information About the Current Build
 `grunt ender --info` or `grunt ender:info`

--- a/tasks/ender.js
+++ b/tasks/ender.js
@@ -10,17 +10,17 @@
 
 module.exports = function(grunt) {
 
+  var ender = require("ender");
+  var util = require("util");
+  var file = require("file");
+
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
-  grunt.registerTask("ender", "Execute the Ender build", function(target) {
-    var ender = require("ender");
-    var util = require("util");
-    var file = require("file");
+  grunt.registerMultiTask("ender", "Execute the Ender build", function(target) {
+    var done = this.async();
 
-    var options = this.options({
-      output: "ender"
-    });
+    var options = this.data;
 
     if (!options.dependencies) { grunt.fail.warn("No ender dependencies specified!"); }
 
@@ -31,8 +31,6 @@ module.exports = function(grunt) {
 
     // figure out the dependencies
     var dependencies = options.dependencies.reduce(function(x, y) { return x + " " + y; });
-
-    var done = this.async();
 
     // hand off to ender
     if (grunt.option("info")) {

--- a/test/ender_test.js
+++ b/test/ender_test.js
@@ -29,9 +29,11 @@ exports.ender = {
   },
 
   default_options: function(test) {
-    test.expect(2);
+    test.expect(4);
     test.ok(grunt.file.exists("tmp/scripts/ender.js"));
     test.ok(grunt.file.exists("tmp/scripts/ender.min.js"));
+    test.ok(grunt.file.exists("tmp/scripts/ender.dist2.js"));
+    test.ok(grunt.file.exists("tmp/scripts/ender.dist2.min.js"));
     test.done();
   }
 };


### PR DESCRIPTION
For my project I had to build two different ender library, one for the desktop and the other one for the mobile.

I kept the common declaration used in grunt for the Gruntfile.js task :

``` javascript
ender: {
  desktop: {
    output: "scripts/vendor/ender",
    dependencies: ["morpheus", "bean", "bonzo", "domready", "qwery", "valentine"]
  },
  mobile: {
    output: "scripts/vendor/ender.mobile",
    dependencies: ["bean", "bonzo", "domready", "qwery"]
  }
}
```

so you can run only one task by using `$ grunt ender:mobile` or all of them with the default command `$ grunt ender`
