### PR TITLE
Adding event hook for when ender builds finish.

### DIFF
--- a/tasks/ender.js
+++ b/tasks/ender.js
@@ -46,6 +46,7 @@ module.exports = function(grunt) {
       ender.exec(util.format("ender build %s --output %s", dependencies, out), function(error) {
         if (error) { grunt.fail.warn("Could not build ender script!\n--> " + error); }
         done();
+        grunt.event.emit("grunt_ender_build_done");
       });
     }
   });


### PR DESCRIPTION
I am building support for grunt-ender into my grunt-nautilus plugin and this emitter would be really handy to hook into. Usage would be `grunt.event.on( "grunt_ender_build_done", callback )`
