### PR TITLE
Expose real `use` option and allow other options as well

### DIFF
--- a/tasks/ender.js
+++ b/tasks/ender.js
@@ -38,9 +38,16 @@ module.exports = function(grunt) {
     if (grunt.option("info")) {
       // `grunt ender --info`
       ender.exec(util.format("ender info --use %s", out));
-    } else if (target && target !== "build") {
+    } else if (target && target !== "build" && options && ( options.use || options.opts)) {
       // `grunt ender:info` or `grunt ender:refresh`, etc...
-      var exec = util.format("ender %s --use %s --output %s %s %s", target, options.use, out, options.opts, dependencies);
+      if ( options.use && options.opts ) {
+        var exec = util.format("ender %s --use %s --output %s %s %s", target, options.use, out, options.opts, dependencies);
+      } else if ( options.use ) {
+        var exec = util.format("ender %s --use %s --output %s %s", target, options.use, out, dependencies);
+      } else if ( options.opts ) {
+        var exec = util.format("ender %s --output %s %s %s", target, out, options.opts, dependencies);
+      }
+
       ender.exec(exec, function(error) {
         if (error) { grunt.fail.warn(util.format("Could not run `ender %s`!\n--> ", target) + error); }
         done();

--- a/tasks/ender.js
+++ b/tasks/ender.js
@@ -38,9 +38,14 @@ module.exports = function(grunt) {
     if (grunt.option("info")) {
       // `grunt ender --info`
       ender.exec(util.format("ender info --use %s", out));
-    }  else if (target && target !== "build") {
+    } else if (target && target !== "build") {
       // `grunt ender:info` or `grunt ender:refresh`, etc...
-      ender.exec(util.format("ender %s --use %s", target, out));
+      var exec = util.format("ender %s --use %s --output %s %s %s", target, options.use, out, options.opts, dependencies);
+      ender.exec(exec, function(error) {
+        if (error) { grunt.fail.warn(util.format("Could not run `ender %s`!\n--> ", target) + error); }
+        done();
+        grunt.event.emit("grunt_ender_build_done");
+      });
     } else {
       // `grunt ender`
       ender.exec(util.format("ender build %s --output %s", dependencies, out), function(error) {


### PR DESCRIPTION
1. Dependencies should be the direct parameters to `ender`
2. Expose `use`
3. Allow other options added as command string
4. Wrap up for `ender <command>`
5. Thanks for the wonderful plugin. :)
